### PR TITLE
Add pre-commit setup instruction to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # cspell-cli
 
-This is just a simple repository that allows [cspell](https://github.com/streetsidesoftware/cspell) to be installed from github.
+This repository enables using [cspell](https://github.com/streetsidesoftware/cspell) as a [pre-commit](https://pre-commit.com) hook.
 
-To install:
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v5.6.7
+    hooks:
+    - id: cspell
+```
+
+It also allows the `cspell-cli` to be installed directly from github:
 
 ```
 npm install -g git+https://github.com/streetsidesoftware/cspell-cli


### PR DESCRIPTION
Question: Do you prefer the version written explicitly in the readme (`rev: v5.6.7`) or an empty string (`rev: ''`). The former requires updating the readme with every new version, the latter will issue a warning to users and ask them to run `pre-commit autoupdate` which auto-sets `rev` to the latest stable release.