### PR TITLE
Make pre-commit hook pass when no files to check.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,3 +9,4 @@
   language: node
   types: [file]
   verbose: true
+  args: [--no-must-find-files]


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/#new-hooks) allows hooks to configure default arguments to be passed to their entry point to accommodate the fact that many tools are best used with different options in the context of a hook than when run directly. Closes #52.