### PR TITLE
Improve cspell pre-commit hook output

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,5 +8,4 @@
   entry: cspell-cli
   language: node
   types: [file]
-  verbose: true
   args: [--no-must-find-files]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,4 +8,6 @@
   entry: cspell-cli
   language: node
   types: [file]
-  args: [--no-must-find-files]
+  args:
+    - --no-must-find-files
+    - --no-progress


### PR DESCRIPTION
Hey there, thanks a lot for extracting this repo from [cspell](https://github.com/streetsidesoftware/cspell)! Now it's much easier to run cspell through pre-commit. (Previously did that through [this mirror](https://github.com/ComPWA/mirrors-cspell), which I'll archive.)

Here's a suggested change to the hook config, so that it's easier to read the pre-commit output (particularly when running over all files). Pre-commit users can of course configure this themselves through their own `.pre-commit-config.yaml`, but I think this should become the default behaviour.

---

Intended behaviour is shown below. Can be reproduced with:

```bash
pre-commit try-repo . --all-files
```

<details>
<summary>b07cfd1: no verbose</summary>

## Old ([v5.6.7](https://github.com/streetsidesoftware/cspell-cli/tree/v5.6.7))
![image](https://user-images.githubusercontent.com/29308176/134518003-d70c99d5-a490-491a-b598-dafc92b5322d.png)

## New
![image](https://user-images.githubusercontent.com/29308176/134516476-e5c440c2-759d-43d9-a91f-6489b1e39b80.png)

</details>

<details>
<summary>7615279: no progress</summary>

## Old ([v5.6.7](https://github.com/streetsidesoftware/cspell-cli/tree/v5.6.7) / b07cfd1)
![image](https://user-images.githubusercontent.com/29308176/134517382-7c51a24f-a267-473b-9c30-c22a55fd3161.png)

## New
![image](https://user-images.githubusercontent.com/29308176/134516904-dab87cde-f3ee-4bac-93fe-2fc318f03d3b.png)

</details>

