### PR TITLE
Default to No Summary in Pre-commit Hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,3 +11,4 @@
   args:
     - --no-must-find-files
     - --no-progress
+    - --no-summary


### PR DESCRIPTION
Because many often run at once, pre-commit hooks are typically very
quiet by default, outputting only error messages.