### PR TITLE
Don't run spell checking on binary files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
   description: This hook runs CSpell spellchecker
   entry: cspell-cli
   language: node
-  types: [file]
+  types: [text]
   args:
     - --no-must-find-files
     - --no-progress

--- a/README.md
+++ b/README.md
@@ -47,10 +47,8 @@ If you installed the [Code Spell Checker extension](https://marketplace.visualst
 
 ## Install from GitHub
 
-It also allows the `cspell-cli` to be installed directly from github:
+This repo also allows installing the `cspell-cli` directly from GitHub:
 
 ```
 npm install -g git+https://github.com/streetsidesoftware/cspell-cli
 ```
-
-This will add the `cspell-cli` command to npm.


### PR DESCRIPTION
Changes pre-commit `types: [file]` to `types: [text]`.

See https://github.com/pre-commit/pre-commit.com/pull/555#issuecomment-934961443.