### PR TITLE
fix: Update README to use the general version.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.CRLF.txt]
+end_of_line = crlf
+
+[*.noEOL.txt]
+insert_final_newline = false
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.{json,jsonc}]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository enables using [cspell](https://github.com/streetsidesoftware/csp
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v5.6.11
+    rev: v5
     hooks:
       - id: cspell
 ```


### PR DESCRIPTION
The major version tag will be kept up to date with the latest release.