### PR TITLE
Add Dockerfile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: docker build -t cspell .
-      - run: docker run -it -v $(pwd):/workdir cspell
+      - run: docker run -v $(pwd):/workdir cspell
 
 # cspell:ignore workdir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,13 @@ jobs:
 
       # Ensure the repository is clean after build & test
       - run: git --no-pager diff --compact-summary --exit-code
+
+  test-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: docker build -t cspell .
+      - run: docker run -it -v $(pwd):/workdir cspell
+
+# cspell:ignore workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:16.16.0
+
+WORKDIR /app
+COPY package-lock.json package.json index.js ./
+RUN npm install --production
+RUN npm install --global
+
+WORKDIR /workdir
+ENTRYPOINT [ "cspell-cli" ]


### PR DESCRIPTION
## Why

Part of https://github.com/streetsidesoftware/cspell/issues/3270

## What

Add `Dockerfile` for a building container image with `cspell-cli`.

## Testing

CI - added a new `test-docker` job to `Test` GitHub workflow

Linux and macOS (Bash or Zsh):

```sh
docker build -t cspell . && docker run -v $(pwd):/workdir cspell 
```

Windows (Git Bash):

```sh
docker build -t cspell . && docker run -v $(pwd -W):/workdir cspell 
```

Windows (PowerShell):

```powershell
docker build -t cspell .
docker run -v ${PWD}:/workdir cspell 
```

## Follow-ups

Preferably as separate PRs:

1. Add/update release GitHub workflow that publishes the container image to GitHub docker registry. See: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
1. Add instructions to `README.md` describing how to use the docker image.
1. Add dependabot configuration to bump the `node` base image (but minor and patch so that we stay on the Node.js LTS version)
