### PR TITLE
Add workflow_dispatch for all GitHub workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - cspell4
+  workflow_dispatch:
   schedule:
     - cron: "0 23 * * 0"
 

--- a/.github/workflows/cspell-action.yml
+++ b/.github/workflows/cspell-action.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   cspell:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
 name: release-please
 jobs:
   release-please:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   test-old-node-versions:


### PR DESCRIPTION
## Why

In order to enable running GitHub workflows on forks.
It is especially helpful for "first contributions" when GitHub Actions need to be manually triggered by the maintainer.

<img width="423" alt="image" src="https://user-images.githubusercontent.com/5067549/181097878-752f6dd2-fd20-4f81-a5a0-bff2a620908a.png">



## What

Add `workflow_dispatch` for all GitHub workflows