### PR TITLE
chore: keep README.md version number up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@
 
 This repository enables using [cspell](https://github.com/streetsidesoftware/cspell) as a [pre-commit](https://pre-commit.com) hook.
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v6.2.0
+    rev: v6.31.0
     hooks:
       - id: cspell
 ```
+
+<!-- x-release-please-end -->
 
 ## Setup Custom Dictionary
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,10 @@
       "bumpMinorPreMajor": false,
       "bumpPatchForMinorPreMajor": false,
       "changelogPath": "CHANGELOG.md",
-      "versioning": "default"
+      "versioning": "default",
+      "extra-files": [
+        "README.md"
+      ]
     }
   }
 }


### PR DESCRIPTION
1. Bump version number in `README.md`, and add annotations for `release-please`.
2. Modify `release-please-config.json` to update the version number in `README.md` when releasing a new version.

I haven't tested these changes -- and I'm new to `release-please` -- but I'm reasonably confident they will work, I read their docs and found some examples in their tests and issues. Fingers crossed!

Docs: https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files ([versioned link](https://github.com/googleapis/release-please/blob/122820d/docs/customizing.md))