### PR TITLE
fix: force file paths in pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,3 +13,4 @@
     - --no-progress
     - --no-summary
     - --gitignore
+    - --files # this needs to be the last argument so that the paths are passed correctly.


### PR DESCRIPTION
Make sure pre-commit files are treated as files, not globs.

fixes #539