### PR TITLE
fix: Revert "feat: Update CSpell version (8.19.0)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.17.3",
       "license": "MIT",
       "dependencies": {
-        "cspell": "^8.19.0"
+        "cspell": "^8.18.1"
       },
       "bin": {
         "cspell-cli": "index.js"
@@ -23,27 +23,27 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.19.0.tgz",
-      "integrity": "sha512-ISPiC8YQr+09aGFK6VPxxygp3BOSvU/Axlvl2eCYhH+vS+3NoYWakn+UZJ6DoveIsfFWp9LpbU9/xLea8qbG4g==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.18.1.tgz",
+      "integrity": "sha512-gxciVVfQqCVXYH0p2Q5D7x7/SgaW3Wv5UjRwO+TCme0P2lVLl/IcfjkujZX+6UQkT7X4QRglXo1QN141UcCRCQ==",
       "license": "MIT",
       "dependencies": {
         "@cspell/dict-ada": "^4.1.0",
         "@cspell/dict-al": "^1.1.0",
-        "@cspell/dict-aws": "^4.0.10",
+        "@cspell/dict-aws": "^4.0.9",
         "@cspell/dict-bash": "^4.2.0",
-        "@cspell/dict-companies": "^3.1.15",
-        "@cspell/dict-cpp": "^6.0.8",
+        "@cspell/dict-companies": "^3.1.14",
+        "@cspell/dict-cpp": "^6.0.6",
         "@cspell/dict-cryptocurrencies": "^5.0.4",
         "@cspell/dict-csharp": "^4.0.6",
         "@cspell/dict-css": "^4.0.17",
         "@cspell/dict-dart": "^2.3.0",
-        "@cspell/dict-data-science": "^2.0.8",
+        "@cspell/dict-data-science": "^2.0.7",
         "@cspell/dict-django": "^4.1.4",
-        "@cspell/dict-docker": "^1.1.13",
+        "@cspell/dict-docker": "^1.1.12",
         "@cspell/dict-dotnet": "^5.0.9",
         "@cspell/dict-elixir": "^4.0.7",
-        "@cspell/dict-en_us": "^4.4.1",
+        "@cspell/dict-en_us": "^4.3.35",
         "@cspell/dict-en-common-misspellings": "^2.0.10",
         "@cspell/dict-en-gb": "1.1.33",
         "@cspell/dict-filetypes": "^3.0.11",
@@ -51,9 +51,9 @@
         "@cspell/dict-fonts": "^4.0.4",
         "@cspell/dict-fsharp": "^1.1.0",
         "@cspell/dict-fullstack": "^3.2.6",
-        "@cspell/dict-gaming-terms": "^1.1.1",
+        "@cspell/dict-gaming-terms": "^1.1.0",
         "@cspell/dict-git": "^3.0.4",
-        "@cspell/dict-golang": "^6.0.20",
+        "@cspell/dict-golang": "^6.0.19",
         "@cspell/dict-google": "^1.0.8",
         "@cspell/dict-haskell": "^4.0.5",
         "@cspell/dict-html": "^4.0.11",
@@ -66,25 +66,25 @@
         "@cspell/dict-lorem-ipsum": "^4.0.4",
         "@cspell/dict-lua": "^4.0.7",
         "@cspell/dict-makefile": "^1.0.4",
-        "@cspell/dict-markdown": "^2.0.10",
+        "@cspell/dict-markdown": "^2.0.9",
         "@cspell/dict-monkeyc": "^1.0.10",
-        "@cspell/dict-node": "^5.0.7",
-        "@cspell/dict-npm": "^5.2.0",
+        "@cspell/dict-node": "^5.0.6",
+        "@cspell/dict-npm": "^5.1.31",
         "@cspell/dict-php": "^4.0.14",
         "@cspell/dict-powershell": "^5.0.14",
         "@cspell/dict-public-licenses": "^2.0.13",
-        "@cspell/dict-python": "^4.2.17",
+        "@cspell/dict-python": "^4.2.16",
         "@cspell/dict-r": "^2.1.0",
         "@cspell/dict-ruby": "^5.0.8",
         "@cspell/dict-rust": "^4.0.11",
         "@cspell/dict-scala": "^5.0.7",
         "@cspell/dict-shell": "^1.1.0",
-        "@cspell/dict-software-terms": "^5.0.5",
+        "@cspell/dict-software-terms": "^5.0.2",
         "@cspell/dict-sql": "^2.2.0",
         "@cspell/dict-svelte": "^1.0.6",
         "@cspell/dict-swift": "^2.0.5",
         "@cspell/dict-terraform": "^1.1.1",
-        "@cspell/dict-typescript": "^3.2.1",
+        "@cspell/dict-typescript": "^3.2.0",
         "@cspell/dict-vue": "^3.0.4"
       },
       "engines": {
@@ -92,30 +92,30 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.19.0.tgz",
-      "integrity": "sha512-MkpBlQizR9UxwrYhzJgz02yzgrmfyPpb+QctwKNJthscymhjufkBFnBj5cHK5fbmp+/y4jXxaX+Ew6QUFiJsNw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.18.1.tgz",
+      "integrity": "sha512-/U3/8bcOL5O35fI9F7nN7Mhic0K01ZRxRV/+5jj7atltBbqgFSxViHCZBX0lDZJM96gUHn+3r6q6/8VEJahpDA==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.19.0"
+        "@cspell/cspell-types": "8.18.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.19.0.tgz",
-      "integrity": "sha512-OtgF/oQ3n6T/qM+fIWLfhOhW0fLSPnpZGOZi7uKSCJZxnHKVk0h+7zNPlLkcDHrhxZP4Df76S9z7jU5iEC2oYA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.18.1.tgz",
+      "integrity": "sha512-QHndTQPkR1c02pvvQ7UKFtLjCXgY0OcX8zjTLrCkynmcQxJFjAZAh9cJ7NMOAxab+ciSnkaVf4KWaRSEG17z8Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.19.0.tgz",
-      "integrity": "sha512-/iA0ALPgnX9bN6Xwt5hfbmh7oTVoXNDS5k0rBZDGz+w0/zKn6T1XxPUIlkz5T2e4nSKOmmlpcNZGdroA7GdUfA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.18.1.tgz",
+      "integrity": "sha512-T2sUBv0p9Hnfyg1xT1u3ESKuIWaaIDo0I8idh5DSlTpHgLjdIeAwasmFjEJ28qZv8OKSGawcSQKgJbStfbZASQ==",
       "license": "MIT",
       "dependencies": {
         "global-directory": "^4.0.1"
@@ -125,18 +125,18 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.19.0.tgz",
-      "integrity": "sha512-L5knViQupeqBMwfP0iQ3+oDQ8s1pzRodcOR/6H2b9cGjuIFPIcsfclzuqVzzMtfptY25WCEpC735pwcfyIRnnQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.18.1.tgz",
+      "integrity": "sha512-PwWl7EyhGIu4wHEhvBJb6xVlqMtFwQk0qLDArBvugL6nA+MX9NfG/w7PTgS7tCkFjVF1ku2sDzDLTDWwEk+MLw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.19.0.tgz",
-      "integrity": "sha512-iWOtHogjZdRbX4zBlXRdh3+NB1DqgBD68+U70yL9+r37szMd8D5tRcm3h98yzhfbXW34zWhvfOiXvRi28SH4ng==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.18.1.tgz",
+      "integrity": "sha512-d/nMG+qnMbI/1JPm+lD0KcKpgtEHMRsHxkdtGyNCDgvHL/JOGaSHc5ERS3IUgBW0Dfya/3z9wPdaMcHEzt7YCQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -170,15 +170,15 @@
       }
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.15.tgz",
-      "integrity": "sha512-vnGYTJFrqM9HdtgpZFOThFTjlPyJWqPi0eidMKyZxMKTHhP7yg6mD5X9WPEPvfiysmJYMnA6KKYQEBqoKFPU9g==",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.14.tgz",
+      "integrity": "sha512-iqo1Ce4L7h0l0GFSicm2wCLtfuymwkvgFGhmu9UHyuIcTbdFkDErH+m6lH3Ed+QuskJlpQ9dM7puMIGqUlVERw==",
       "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.8.tgz",
-      "integrity": "sha512-BzurRZilWqaJt32Gif6/yCCPi+FtrchjmnehVEIFzbWyeBd/VOUw77IwrEzehZsu5cRU91yPWuWp5fUsKfDAXA==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.7.tgz",
+      "integrity": "sha512-mk0AUx6au1BJQBTT2Uq9L+y43E0Cy0Vcm6TrK3Toi2iuBLWOnDR/xRE4nZADBsi6WnWoiyl3/QqA1gW2zPkGvQ==",
       "license": "MIT"
     },
     "node_modules/@cspell/dict-cryptocurrencies": {
@@ -236,9 +236,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.2.tgz",
-      "integrity": "sha512-mvpv2kWayuOExCnDgvhlYDoW7gbGvGVTyuof9aFGy0+8ALYAJ2AtlvYCqzdTTKvvsYBrxAEEWFkUh75kHnHibg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.0.tgz",
+      "integrity": "sha512-TEfVT2NwvI9k1/ECjuC7GbULxenjJAbTLWMri1eMRk3mRGtqg5j0XzvvNRFuJWq8X48MdGVjsD+ZVI/VR94+eQ==",
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
@@ -398,9 +398,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.0.tgz",
-      "integrity": "sha512-kTUdbSE8SuIMKMlASMbI8/SEwv3EmI8eBcwdrtu4PHA+XVx+8JvQCB5fcWK9mn/94Y7LQ1kDIm+yfAZfwopY0A==",
+      "version": "5.1.34",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.34.tgz",
+      "integrity": "sha512-UrUYqRQX864Cx9QJkg7eEIxmjYGqcje+x1j7bzl+a3jCKwT6jm+p0off6VEOf3EReHP0dWUSYO3Q0+pLL/N+FQ==",
       "license": "MIT"
     },
     "node_modules/@cspell/dict-php": {
@@ -503,12 +503,12 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.19.0.tgz",
-      "integrity": "sha512-VrgcgoSyspbXFalaFZgwQXCZQEUR/iKxyqM0R/gRQOk/cRKUnWOkaV0oRJcHhNXZra48boElWXIOlIDXiGhcJQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.18.1.tgz",
+      "integrity": "sha512-VJHfS/Iv0Rx7wn1pjPmwgsaw6r72N5Cx2gL0slWk8Cogc8YiK7/6jsGnsvxJZVkHntJoiT8PrkIvhNKb3awD3g==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.19.0",
+        "@cspell/url": "8.18.1",
         "import-meta-resolve": "^4.1.0"
       },
       "engines": {
@@ -516,27 +516,27 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.19.0.tgz",
-      "integrity": "sha512-fsSry1JPksv/LOcFryMPWPmudFekH5SD1UY6WJ2GL8CNryILbbSypEJNriE/hA1UtOTDEBY0bTlsj81GzfW0Ww==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.18.1.tgz",
+      "integrity": "sha512-vTOb2itP0pjrccvt8wcKiTGyw0pFMTPI85H12T6n8ZhqXTktPgQH2gEf/SU/5tkPNnBKr4GJ+FdU5hJ27HzgXQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.19.0.tgz",
-      "integrity": "sha512-8T/jf/y5cxkizozFJqKuxB+gYhB3JFdjVZjVGKIK8KLT7ebnO1bkEKe9fbZByZxJQxLVvwIdwWE3EKr5oFNptA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.18.1.tgz",
+      "integrity": "sha512-gsgv+5ZQD4aHNHDdfNGoafVYkqRynyYgaodt9Dp/3o0YKYcxGf2jrX8SJ35MfZ61qln0n7P4Djrg+bFV2zNH5w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.19.0.tgz",
-      "integrity": "sha512-zleyW54/TUYzlWd+5fJev17pk+jpploJnE/NwactKFmSg3VQi7AbwYWz3/hwLyRDz6cpfLKPKk4aJB6ay5QpSg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.18.1.tgz",
+      "integrity": "sha512-FRJbLYDC9ucpTOzbF6MohP2u5X3NU5L0RoVuoYCynqm/QOI38XP6WOEaI4H58CAn857bOIKZk0LZRPTGzi6Qlg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0"
@@ -865,24 +865,24 @@
       "license": "MIT"
     },
     "node_modules/cspell": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.19.0.tgz",
-      "integrity": "sha512-3I6Cz2JZ9iJ5+/zqm1Wy5ak5LSebv/dsy8LGjQ/MlVeofsH7GLFkN/c/krCJzY/KxmgskkxzHZT4fl78/LFVdg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.18.1.tgz",
+      "integrity": "sha512-RE3LIgN9NAVcYBNX2NQVhLergok8EPymOuCUhu1vBR8cjRmioksn3CJeCoQgD8rPjalM+S9thYkMtOZc5Jjv2A==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.19.0",
-        "@cspell/cspell-pipe": "8.19.0",
-        "@cspell/cspell-types": "8.19.0",
-        "@cspell/dynamic-import": "8.19.0",
-        "@cspell/url": "8.19.0",
+        "@cspell/cspell-json-reporter": "8.18.1",
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-types": "8.18.1",
+        "@cspell/dynamic-import": "8.18.1",
+        "@cspell/url": "8.18.1",
         "chalk": "^5.4.1",
         "chalk-template": "^1.1.0",
         "commander": "^13.1.0",
-        "cspell-dictionary": "8.19.0",
-        "cspell-gitignore": "8.19.0",
-        "cspell-glob": "8.19.0",
-        "cspell-io": "8.19.0",
-        "cspell-lib": "8.19.0",
+        "cspell-dictionary": "8.18.1",
+        "cspell-gitignore": "8.18.1",
+        "cspell-glob": "8.18.1",
+        "cspell-io": "8.18.1",
+        "cspell-lib": "8.18.1",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.1.0",
         "get-stdin": "^9.0.0",
@@ -901,28 +901,28 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.19.0.tgz",
-      "integrity": "sha512-WcLOfdj2ZHXPPL3oAvqBhTQTPt3ZgErzMfR6OWwejO/19UUPe9yfr9oCENfjTTVBvsDhkqz40tawM5Y1Uh3WRQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.18.1.tgz",
+      "integrity": "sha512-zdJ0uhLROSUrHoibysPw+AkxKPUmiG95hDtiL7s8smewkuaS1hpjqwsDBx981nHYs3xW3qDUfVATrAkSzb0VMw==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.19.0",
+        "@cspell/cspell-types": "8.18.1",
         "comment-json": "^4.2.5",
-        "yaml": "^2.7.1"
+        "yaml": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.19.0.tgz",
-      "integrity": "sha512-kbJf5IiJu5l3jnobSvGx0q0PlkK12q9Z2g3bLSvatw/iEleiZ7xsA7Yy1jf3AL+iB1gHxXqCZMEUulFSfT0JZA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.18.1.tgz",
+      "integrity": "sha512-vKHEPSfkMKMR4S4tk6K2vHC+f3kdJK8Kdh/C0jDh6RRDjDsyAPxshtbremxOgAX6X8GaRUCROoMZ7FhB92+Y9w==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.19.0",
-        "@cspell/cspell-types": "8.19.0",
-        "cspell-trie-lib": "8.19.0",
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-types": "8.18.1",
+        "cspell-trie-lib": "8.18.1",
         "fast-equals": "^5.2.2"
       },
       "engines": {
@@ -930,14 +930,14 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.19.0.tgz",
-      "integrity": "sha512-iV/cbVlKeIvnyJ6PGYneQgQK+8L62dhoLbyO+9JIOiW0UBqUgEsehImn8gipfSBlgvydbUFwvN3jW4xfjAsl/Q==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.18.1.tgz",
+      "integrity": "sha512-gp/AdUtW6FqpKY4YyYJ3kz0OsXApwsV1FOUA9Z0VnOYKVZtt2snh4uNlI4Ltq+wh7pDU8mqaPWmX6Xy+HSRDkQ==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.19.0",
-        "cspell-glob": "8.19.0",
-        "cspell-io": "8.19.0"
+        "@cspell/url": "8.18.1",
+        "cspell-glob": "8.18.1",
+        "cspell-io": "8.18.1"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
@@ -947,12 +947,12 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.19.0.tgz",
-      "integrity": "sha512-RejVJrORHV8dbbZ0XQvzFAKlnyrFrOTwekgMapb/+FU8/fnoE9id3JZR8NUNRCjs+d4kwDBP3Jh11iSLO+9JlA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.18.1.tgz",
+      "integrity": "sha512-tlZXvzsN7dByHo69dz/HbJuQDUtrfhdioZ/LHaW7W9diG9NpaghgEfyX4fmsIXjU/2f66LDpYVY6osjtlOgyrg==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.19.0",
+        "@cspell/url": "8.18.1",
         "micromatch": "^4.0.8"
       },
       "engines": {
@@ -960,13 +960,13 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.19.0.tgz",
-      "integrity": "sha512-uMMJyiu82cxeLGFtZr6ArtIqwyRn2pZzM+O1VAOD3NMoslyx52Lij0/qrJsfCF0eobhZDU8cNdgNy99OPeMtWg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.18.1.tgz",
+      "integrity": "sha512-V6XTN1B++7EzJA0H4g4XbNJtqm6Y3/iXdLeZ6sMRDaNFKXXwTbWRtn8gukDQIytyw09AnCUKeqGSzCVqw26Omg==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.19.0",
-        "@cspell/cspell-types": "8.19.0"
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-types": "8.18.1"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -976,40 +976,40 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.19.0.tgz",
-      "integrity": "sha512-F3ciuf2yEH5k1pMdRRI6z6gWyQL/UsTNbHHB5TI0meOduha20CdcgKW3bAPypUbeub6qCoNq5bYUan1LHwfswA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.18.1.tgz",
+      "integrity": "sha512-mm9SUEF2yShuTXDSjCbsAqYTEb6jrtgcCnlqIzpsZOJOOe+zj/VyzTy2NJvOrdvR59dikdaqB75VGBMfHi804g==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.19.0",
-        "@cspell/url": "8.19.0"
+        "@cspell/cspell-service-bus": "8.18.1",
+        "@cspell/url": "8.18.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.19.0.tgz",
-      "integrity": "sha512-TyuSV2onWGwIMx+WxCcLwznYDovAV1cQ2atGhgytfe23JvJo18QEiiNd0u2T3y+WVAJvRal68mhxSdxqXLYL0w==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.18.1.tgz",
+      "integrity": "sha512-t1j+XB7515yHmrczK6I1N6j0a72vmL/6OxsMJnCucHC6DO0WkOqmHulNRH7LpFacnns0dx15lmrAqPg7gQFcIg==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.19.0",
-        "@cspell/cspell-pipe": "8.19.0",
-        "@cspell/cspell-resolver": "8.19.0",
-        "@cspell/cspell-types": "8.19.0",
-        "@cspell/dynamic-import": "8.19.0",
-        "@cspell/filetypes": "8.19.0",
-        "@cspell/strong-weak-map": "8.19.0",
-        "@cspell/url": "8.19.0",
+        "@cspell/cspell-bundled-dicts": "8.18.1",
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-resolver": "8.18.1",
+        "@cspell/cspell-types": "8.18.1",
+        "@cspell/dynamic-import": "8.18.1",
+        "@cspell/filetypes": "8.18.1",
+        "@cspell/strong-weak-map": "8.18.1",
+        "@cspell/url": "8.18.1",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "8.19.0",
-        "cspell-dictionary": "8.19.0",
-        "cspell-glob": "8.19.0",
-        "cspell-grammar": "8.19.0",
-        "cspell-io": "8.19.0",
-        "cspell-trie-lib": "8.19.0",
+        "cspell-config-lib": "8.18.1",
+        "cspell-dictionary": "8.18.1",
+        "cspell-glob": "8.18.1",
+        "cspell-grammar": "8.18.1",
+        "cspell-io": "8.18.1",
+        "cspell-trie-lib": "8.18.1",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.2.2",
         "gensequence": "^7.0.0",
@@ -1024,13 +1024,13 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.19.0.tgz",
-      "integrity": "sha512-ZCC8PaHRpB5c6qIIuPLVW2ZxSvc0ulAVD7MKL8fnFKSTw68asDrs7BVwLmNTi3cUkXfGXK9fdL32WtO3YOPMFw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.18.1.tgz",
+      "integrity": "sha512-UaB36wsyp2eWeMtrbS6Q2t2WFvpedmGXJ879yHn9qKD7ViyUpI4cAbh6v7gWMUu+gjqCulXtke64k1ddmBihPQ==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.19.0",
-        "@cspell/cspell-types": "8.19.0",
+        "@cspell/cspell-pipe": "8.18.1",
+        "@cspell/cspell-types": "8.18.1",
         "gensequence": "^7.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "cspell": "^8.19.0"
+    "cspell": "^8.18.1"
   },
   "devDependencies": {
     "inject-markdown": "^3.1.4",


### PR DESCRIPTION
Reverts streetsidesoftware/cspell-cli#656

Need to release 8.18 before adding 8.19